### PR TITLE
Remove mansion tax, highlight combined impacts

### DIFF
--- a/editions/2025-12-09-uk-autumn-budget.html
+++ b/editions/2025-12-09-uk-autumn-budget.html
@@ -91,12 +91,29 @@
                                 </tr>
                             </table>
 
+                            <!-- Featured: Combined Impacts -->
+                            <table width="100%" cellpadding="0" cellspacing="0" style="background: linear-gradient(135deg, #E6FFFA 0%, #B2F5EA 100%); border-top: 1px solid #E2E8F0;">
+                                <tr>
+                                    <td style="padding: 28px 40px;">
+                                        <p style="margin: 0 0 8px 0; font-size: 10px; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: #319795;">
+                                            Featured Research
+                                        </p>
+                                        <a href="https://policyengine.org/uk/research/uk-combined-reforms-autumn-budget-2025" style="color: #1D4044; text-decoration: none; font-weight: 700; font-size: 16px; display: block; margin-bottom: 8px;">
+                                            Combined impacts of all Autumn Budget reforms →
+                                        </a>
+                                        <p style="margin: 0; font-size: 13px; line-height: 1.55; color: #285E61;">
+                                            How all nine reforms interact: two-child limit repeal, fuel duty freeze, rail fares freeze, threshold freeze extension, and more. Includes constituency-level breakdowns and impacts by income decile.
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
                             <!-- Policy Analysis Section -->
                             <table width="100%" cellpadding="0" cellspacing="0">
                                 <tr>
                                     <td style="padding: 36px 40px 24px 40px;">
                                         <p style="margin: 0; font-size: 11px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #319795;">
-                                            Policy Analysis
+                                            Policy Deep-Dives
                                         </p>
                                     </td>
                                 </tr>
@@ -180,55 +197,14 @@
                                 </tr>
                             </table>
 
-                            <!-- Policy 3: April 2025 tax changes -->
-                            <table width="100%" cellpadding="0" cellspacing="0" style="border-bottom: 1px solid #F1F5F9;">
-                                <tr>
-                                    <td style="padding: 28px 40px;">
-                                        <table width="100%" cellpadding="0" cellspacing="0">
-                                            <tr>
-                                                <td style="width: 56px; vertical-align: top;">
-                                                    <span class="policy-number" style="font-size: 56px; font-weight: 800; color: #E6FFFA; line-height: 1; letter-spacing: -0.03em;">03</span>
-                                                </td>
-                                                <td style="vertical-align: top; padding-left: 8px;">
-                                                    <a href="https://policyengine.org/uk/research/impact-of-tax-changes-2025-2026" style="color: #101828; text-decoration: none; font-weight: 700; font-size: 16px; display: block; margin-bottom: 8px; line-height: 1.3;">
-                                                        April 2025 tax changes
-                                                        <span style="color: #319795;"> →</span>
-                                                    </a>
-                                                    <p style="margin: 0 0 12px 0; font-size: 13px; line-height: 1.55; color: #475569;">
-                                                        Combined impact of employer NI, CGT, SDLT, and Council Tax reforms.
-                                                    </p>
-                                                    <!-- Stats row -->
-                                                    <table class="stat-grid" width="100%" cellpadding="0" cellspacing="0">
-                                                        <tr>
-                                                            <td class="stat-item" style="width: 33%; vertical-align: top; padding-right: 12px;">
-                                                                <p style="margin: 0 0 2px 0; font-size: 18px; font-weight: 700; color: #1D4044;">£31.8bn</p>
-                                                                <p style="margin: 0; font-size: 10px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.05em; color: #94A3B8;">Revenue</p>
-                                                            </td>
-                                                            <td class="stat-item" style="width: 33%; vertical-align: top; padding-right: 12px;">
-                                                                <p style="margin: 0 0 2px 0; font-size: 18px; font-weight: 700; color: #1D4044;">£2,754</p>
-                                                                <p style="margin: 0; font-size: 10px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.05em; color: #94A3B8;">Top decile</p>
-                                                            </td>
-                                                            <td class="stat-item" style="width: 33%; vertical-align: top;">
-                                                                <p style="margin: 0 0 2px 0; font-size: 18px; font-weight: 700; color: #1D4044;">£808</p>
-                                                                <p style="margin: 0; font-size: 10px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.05em; color: #94A3B8;">Bottom decile</p>
-                                                            </td>
-                                                        </tr>
-                                                    </table>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </td>
-                                </tr>
-                            </table>
-
-                            <!-- Policy 4: Threshold freeze -->
+                            <!-- Policy 3: Threshold freeze -->
                             <table width="100%" cellpadding="0" cellspacing="0">
                                 <tr>
                                     <td style="padding: 28px 40px;">
                                         <table width="100%" cellpadding="0" cellspacing="0">
                                             <tr>
                                                 <td style="width: 56px; vertical-align: top;">
-                                                    <span class="policy-number" style="font-size: 56px; font-weight: 800; color: #E6FFFA; line-height: 1; letter-spacing: -0.03em;">04</span>
+                                                    <span class="policy-number" style="font-size: 56px; font-weight: 800; color: #E6FFFA; line-height: 1; letter-spacing: -0.03em;">03</span>
                                                 </td>
                                                 <td style="vertical-align: top; padding-left: 8px;">
                                                     <a href="https://policyengine.org/uk/research/uk-income-tax-ni-reforms-2025" style="color: #101828; text-decoration: none; font-weight: 700; font-size: 16px; display: block; margin-bottom: 8px; line-height: 1.3;">
@@ -245,21 +221,14 @@
                                 </tr>
                             </table>
 
-                            <!-- All Autumn Budget Research -->
+                            <!-- Individual Policy Analysis -->
                             <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #F8FAFC; border-top: 1px solid #E2E8F0;">
                                 <tr>
                                     <td style="padding: 28px 40px;">
                                         <p style="margin: 0 0 16px 0; font-size: 11px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #64748B;">
-                                            All Autumn Budget Research
+                                            Individual Policy Analysis
                                         </p>
                                         <table width="100%" cellpadding="0" cellspacing="0">
-                                            <tr>
-                                                <td style="padding: 8px 0; border-bottom: 1px solid #E2E8F0;">
-                                                    <a href="https://policyengine.org/uk/research/uk-combined-reforms-autumn-budget-2025" style="color: #344054; text-decoration: none; font-size: 14px; font-weight: 500;">
-                                                        Combined impacts of all reforms →
-                                                    </a>
-                                                </td>
-                                            </tr>
                                             <tr>
                                                 <td style="padding: 8px 0; border-bottom: 1px solid #E2E8F0;">
                                                     <a href="https://policyengine.org/uk/research/uk-two-child-limit" style="color: #344054; text-decoration: none; font-size: 14px; font-weight: 500;">
@@ -297,15 +266,15 @@
                                             </tr>
                                             <tr>
                                                 <td style="padding: 8px 0; border-bottom: 1px solid #E2E8F0;">
-                                                    <a href="https://policyengine.org/uk/research/uk-mansion-tax-autumn-budget" style="color: #344054; text-decoration: none; font-size: 14px; font-weight: 500;">
-                                                        Mansion tax →
+                                                    <a href="https://policyengine.org/uk/research/high-value-council-tax-surcharge" style="color: #344054; text-decoration: none; font-size: 14px; font-weight: 500;">
+                                                        High value council tax surcharge →
                                                     </a>
                                                 </td>
                                             </tr>
                                             <tr>
                                                 <td style="padding: 8px 0;">
-                                                    <a href="https://policyengine.org/uk/research/high-value-council-tax-surcharge" style="color: #344054; text-decoration: none; font-size: 14px; font-weight: 500;">
-                                                        High value council tax surcharge →
+                                                    <a href="https://policyengine.org/uk/research/impact-of-tax-changes-2025-2026" style="color: #344054; text-decoration: none; font-size: 14px; font-weight: 500;">
+                                                        April 2025 tax changes →
                                                     </a>
                                                 </td>
                                             </tr>


### PR DESCRIPTION
- Remove mansion tax link (not relevant to Autumn Budget 2025)
- Add featured section for combined impacts post with description
- Rename 'All Autumn Budget Research' to 'Individual Policy Analysis'

🤖 Generated with [Claude Code](https://claude.com/claude-code)